### PR TITLE
os-wrappers-test: F_DUPFD_CLOEXEC may not be defined

### DIFF
--- a/tests/os-wrappers-test.c
+++ b/tests/os-wrappers-test.c
@@ -124,12 +124,16 @@ fcntl(int fd, int cmd, ...)
 
 	wrapped_calls_fcntl++;
 
+#ifdef F_DUPFD_CLOEXEC
 	if (fall_back && (cmd == F_DUPFD_CLOEXEC)) {
 		errno = EINVAL;
 		return -1;
 	}
+#endif
 	switch (cmd) {
+#ifdef F_DUPFD_CLOEXEC
 	case F_DUPFD_CLOEXEC:
+#endif
 	case F_DUPFD:
 	case F_SETFD:
 		va_start(ap, cmd);


### PR DESCRIPTION
Here the macro was missed.